### PR TITLE
Fixes

### DIFF
--- a/ethanol/ethanol/ap.py
+++ b/ethanol/ethanol/ap.py
@@ -141,9 +141,10 @@ def add_ap(client_address):
         __list_of_aps[ip] = AP(ip, port)
         log.info("Adding AP with IP %s to the list of connected aps (size %d)"
                  % (ip, len(__list_of_aps)))
+        return __list_of_aps[ip]
     else:
         log.debug('AP %s exists' % ip)
-        pass
+        return None # returns None if no new AP object was created
 
 
 def remove_ap_byIP(ip):

--- a/ethanol/ethanol/ap.py
+++ b/ethanol/ethanol/ap.py
@@ -176,7 +176,7 @@ class AP(object):
         """
         # import placed here to avoid 'import loop'
         from pox.ethanol.ethanol.radio import Radio
-        from pox.ethanol.ethanol.network import Network
+        from pox.ethanol.ethanol.network import Network, add_network
 
         self.__id = uuid.uuid4()  #
         # client_address tuple
@@ -221,7 +221,10 @@ class AP(object):
                     log.info("Detected a invalid SSID!!!")
                 else:
                     net = Network(ssid.ssid)
-                    log.info('[%s] added to network (SSID) list', ssid.ssid)
+                    if add_network(ssid.ssid, net):
+                        log.info('[%s] added to network (SSID) list', ssid.ssid)
+                    else:
+                        log.debug('Network SSID %s already exists', ssid.ssid)
             log.info('Creating and association the VAP objects')
             #
             # retrieve configured vaps

--- a/ethanol/ethanol/network.py
+++ b/ethanol/ethanol/network.py
@@ -103,7 +103,7 @@ class Network(object):
           create a network with ESSID = ssid
         """
         if ssid in list_of_networks():
-            log.debug('ssid %s already exists')
+            log.debug('ssid %s already exists', ssid)
             raise ValueError("SSID %s already exists!" % ssid)
 
         self.__id = uuid4()  # random UUID

--- a/ethanol/ethanol/network.py
+++ b/ethanol/ethanol/network.py
@@ -102,9 +102,9 @@ class Network(object):
         """
           create a network with ESSID = ssid
         """
-        if ssid in list_of_networks():
-            log.debug('ssid %s already exists', ssid)
-            raise ValueError("SSID %s already exists!" % ssid)
+        #if ssid in list_of_networks():
+        #    log.debug('ssid %s already exists', ssid)
+        #    raise ValueError("SSID %s already exists!" % ssid)
 
         self.__id = uuid4()  # random UUID
 
@@ -112,8 +112,8 @@ class Network(object):
         self.__listVAP = []
         self.__msg_id = 0  # message id used to identify the msg to the device
         log.info('SSID: %s', self.__SSID)
-        add_network(self.__SSID, self)
-        log.info('constructor Network %s ended', self.__SSID)
+        #add_network(self.__SSID, self)
+        log.info('Constructor Network %s ended', self.__SSID)
 
     def __del__(self):
         """

--- a/ethanol/ssl_message/msg_enabled.py
+++ b/ethanol/ssl_message/msg_enabled.py
@@ -55,7 +55,7 @@ def is_802_11e_enabled(server, id=0, intf_name=DEFAULT_WIFI_INTFNAME, sta_ip=Non
       @return: msg - received message
     """
     return __get_enabled(server=server, id=id,
-                         sta_ip=sta_ip, sta_port=sta_port, m_type=MSG_TYPE.MSG_GET_802_11E_ENABLED)
+                         sta_ip=sta_ip, sta_port=sta_port, intf_name=intf_name, m_type=MSG_TYPE.MSG_GET_802_11E_ENABLED)
 
 
 def is_fastbsstransition_compatible(server, id=0, intf_name=DEFAULT_WIFI_INTFNAME, sta_ip=None, sta_port=0):
@@ -92,8 +92,8 @@ def __get_enabled(server, id=0, intf_name=None, sta_ip=None, sta_port=0, m_type=
 
       @return: msg - received message
     """
-    if intf_name is None or m_type in [MSG_TYPE.MSG_GET_802_11E_ENABLED,
-                                       MSG_TYPE.MSG_GET_FASTBSSTRANSITION_COMPATIBLE]:
+    if intf_name is None or m_type not in [MSG_TYPE.MSG_GET_802_11E_ENABLED,
+                                           MSG_TYPE.MSG_GET_FASTBSSTRANSITION_COMPATIBLE]:
         return None, None
 
     """

--- a/ethanol/ssl_message/msg_hello.py
+++ b/ethanol/ssl_message/msg_hello.py
@@ -28,7 +28,7 @@ from pox.ethanol.ssl_message.msg_common import hexadecimal
 from pox.ethanol.ssl_message.msg_common import connect_ssl_socket, len_of_string
 from pox.ethanol.ssl_message.msg_log import log
 
-from pox.ethanol.ethanol.ap import add_ap
+from pox.ethanol.ethanol.ap import add_ap, connected_aps
 from pox.ethanol.ethanol.station import add_station
 
 from pox.ethanol.events import Events
@@ -109,7 +109,8 @@ def process_hello(received_msg, fromaddr):
         # create ap object
         log.debug("\tConnect to AP @ %s:%d" % client_socket)
         ap = add_ap(client_socket)  # returns ap
-        log.debug("AP %s" % ap)
+        log.debug("AP added to the list: %s" % ap)
+        log.debug("List of connected APs: %s", connected_aps())
     elif msg['device_type'] == 2:
         log.info("Connect to STA @ %s:%d" % client_socket)
         station = add_station(client_socket)

--- a/ethanol/ssl_message/msg_hello.py
+++ b/ethanol/ssl_message/msg_hello.py
@@ -106,11 +106,11 @@ def process_hello(received_msg, fromaddr):
 
     log.debug("Hello msg received.")
     if msg['device_type'] == 1:
-        # create ap object
-        log.debug("\tConnect to AP @ %s:%d" % client_socket)
-        ap = add_ap(client_socket)  # returns ap
-        log.debug("AP added to the list: %s" % ap)
-        log.debug("List of connected APs: %s", connected_aps())
+        # Creates and returns ap object if it doesn't already exist
+        ap = add_ap(client_socket)
+        if ap is not None:
+            log.debug("\tConnected to AP @ %s:%d" % client_socket)
+            log.debug("List of connected APs: %s", connected_aps().keys())
     elif msg['device_type'] == 2:
         log.info("Connect to STA @ %s:%d" % client_socket)
         station = add_station(client_socket)

--- a/ethanol/ssl_message/msg_hello.py
+++ b/ethanol/ssl_message/msg_hello.py
@@ -104,7 +104,8 @@ def process_hello(received_msg, fromaddr):
     client_port = msg['tcp_port']
     client_socket = (fromaddr[0], client_port)
 
-    log.debug("Hello msg received.")
+    events_hello.on_change(msg=msg, fromaddr=fromaddr)  # call all registered functions
+    
     if msg['device_type'] == 1:
         # Creates and returns ap object if it doesn't already exist
         ap = add_ap(client_socket)
@@ -115,8 +116,6 @@ def process_hello(received_msg, fromaddr):
         log.info("Connect to STA @ %s:%d" % client_socket)
         station = add_station(client_socket)
         log.debug("Station %s" % station)
-
-    events_hello.on_change(msg=msg, fromaddr=fromaddr)  # call all registered functions
 
     # only send back the same message
     return received_msg


### PR DESCRIPTION
Latest commit is regarding to the instantiation of the network class. The network class is instantiated and add_network is used on ap.py to add it to the set of networks (if it doesn't exist), instead of doing it inside of the constructor itself and raising error if the SSID exists.

Also, the message "SSID added to network (SSID) list" is printed only when the SSID is actually added to the list, and not every hello message.

I'm attaching two prints from before and after corrections, for comparison of DEBUG messages. The flow seem to be more accurate now.

Before:
<img width="1675" alt="before" src="https://user-images.githubusercontent.com/2575969/68674161-165f3d00-0534-11ea-9f21-63da9a5e6269.png">

After:
<img width="1671" alt="after" src="https://user-images.githubusercontent.com/2575969/68674306-60e0b980-0534-11ea-90c9-6a3efbbb50a1.png">
